### PR TITLE
Compute account balance from historical baseline + transactions since

### DIFF
--- a/src/components/Settings/AccountsManagement.tsx
+++ b/src/components/Settings/AccountsManagement.tsx
@@ -335,7 +335,9 @@ export const AccountsManagement: React.FC<AccountsManagementProps> = () => {
         ...accountForm,
         maskedAccountNumber: analysisResult.maskedAccountNumber,
         historicalBalance: accountForm.balance,
-        historicalBalanceDate: analysisResult.balanceDate
+  historicalBalanceDate: analysisResult.balanceDate,
+  // Align with service: set lastSyncDate to the baseline date
+  lastSyncDate: analysisResult.balanceDate
       };
       
       addAccount(newAccountData).then(() => {
@@ -422,7 +424,12 @@ export const AccountsManagement: React.FC<AccountsManagementProps> = () => {
       };
       
       calculateBalance();
-    }, [params.data.id, params.data.balance]);
+    }, [
+      params.data.id,
+      params.data.balance,
+      params.data.historicalBalance,
+      params.data.historicalBalanceDate
+    ]);
 
     if (isLoading) {
       return <span style={{ color: '#666', fontStyle: 'italic' }}>Loading...</span>;

--- a/src/services/accountManagementService.ts
+++ b/src/services/accountManagementService.ts
@@ -367,7 +367,9 @@ ${userPrompt}`;
         historicalBalance: analysis.balance,
         historicalBalanceDate: analysis.balanceDate,
         maskedAccountNumber: analysis.maskedAccountNumber,
-        lastSyncDate: new Date(),
+  // Set lastSyncDate to the historical balance date so future calculations include
+  // all transactions AFTER this date instead of short-circuiting to "now"
+  lastSyncDate: analysis.balanceDate,
         isActive: true
       };
 


### PR DESCRIPTION
- Set lastSyncDate to statement balanceDate when creating accounts from statements (service + UI)
- Calculate current balance: historicalBalance + sum(transactions after historicalBalanceDate)
- Accounts grid recomputes display when baseline fields change

Tests: 6 suites passing; Build: production build compiles successfully.